### PR TITLE
build: move license-files to [project] to avoid setuptools deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 license = "MIT"
+license-files = ["LICENCE"]
 dependencies = ["numpy>=2.3.2,<2.4.0", "requests>=2.31.0,<3.0.0"]
 readme = "README.md"
 
@@ -63,9 +64,6 @@ version = { attr = "preservationeval.__version__" }
 [tool.setuptools.packages.find]
 where = ["src"]
 exclude = ["wip", "wip/*", "*/wip", "*/wip/*", "*tables.py", "*test*"]
-
-[tool.setuptools]
-license-files = ["LICENCE"]
 
 [tool.preservationeval]
 package_dir = "src/preservationeval"


### PR DESCRIPTION
This PR moves license-files to the PEP 621 [project] table and removes the deprecated [tool.setuptools] license-files entry.\n\nThis silences the deprecation warning from setuptools >=77 while still including LICENCE in sdists/wheels.